### PR TITLE
Enable debuginfo stripping and thin LTO for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,7 @@ itertools = "0.10.3"
 
 [lib]
 crate-type = ["cdylib"]
+
+[profile.release]
+lto = true
+strip = "debuginfo"


### PR DESCRIPTION
Stripping debuginfo (leaving symbols) for releases gets the Linux wheel from 1.2MB to 400KB, doing thin LTO on top reduces it to 330KB.